### PR TITLE
Rename FREDRIC_* env vars to FRED_*

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ Command Line
 --------------------------------------------------
 
 The command line utility `fred` acts in a similar way. To set your 
-FRED API Key, simply set it in the environment variable `FREDRIC_KEY`:
+FRED API Key, simply set it in the environment variable `FRED_KEY`:
 
-`$ export FREDRIC_KEY=y0urAP1k3y`
+`$ export FRED_KEY=y0urAP1k3y`
 
 These commands are available:
 
@@ -203,8 +203,8 @@ To enable caching for the command line, simply set one or both of
 these environment variables:
 
 ```
-$ export FREDRIC_CACHE_DIR=cache   # default: 'cache'
-$ export FREDRIC_CACHE_LIFE=120    # default: 3600 (1 hour)
+$ export FRED_CACHE_DIR=cache   # default: 'cache'
+$ export FRED_CACHE_LIFE=120    # default: 3600 (1 hour)
 $ fred see category/children
 # => This call will be cached
 ```

--- a/fredric.gemspec
+++ b/fredric.gemspec
@@ -1,5 +1,6 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'date'
 require 'fredric/version'
 
 Gem::Specification.new do |s|

--- a/lib/fredric/command_line.rb
+++ b/lib/fredric/command_line.rb
@@ -42,7 +42,7 @@ module Fredric
       @csv    = args['--csv']
 
       unless api_key
-        raise Fredric::MissingAuth, "Missing Authentication\nPlease set FREDRIC_KEY=y0urAP1k3y"
+        raise Fredric::MissingAuth, "Missing Authentication\nPlease set FRED_KEY=y0urAP1k3y"
       end
       
       return get    if args['get']
@@ -106,15 +106,15 @@ module Fredric
     end
 
     def api_key
-      ENV['FREDRIC_KEY']
+      ENV['FRED_KEY']
     end
 
     def cache_dir
-      ENV['FREDRIC_CACHE_DIR']
+      ENV['FRED_CACHE_DIR']
     end
 
     def cache_life
-      ENV['FREDRIC_CACHE_LIFE']
+      ENV['FRED_CACHE_LIFE']
     end
 
   end

--- a/lib/fredric/docopt.txt
+++ b/lib/fredric/docopt.txt
@@ -44,16 +44,16 @@ Flags:
     have a 'data' attribute.
 
 Environment Variables:
-  FREDRIC_KEY=y0urAP1k3y
+  FRED_KEY=y0urAP1k3y
     Set Your FRED api key. This variable is required.
 
-  FREDRIC_CACHE_LIFE=360
+  FRED_CACHE_LIFE=360
     Set the number of seconds to consider the cache fresh. This variable
     it optional.
 
-  FREDRIC_CACHE_DIR=./cache
+  FRED_CACHE_DIR=./cache
     Set the cache directory. This variable is optional.
-    If both FREDRIC_CACHE_DIR and FREDRIC_CACHE_LIFE are not set, requests
+    If both FRED_CACHE_DIR and FRED_CACHE_LIFE are not set, requests
     will not be cached.
 
 Examples:

--- a/lib/fredric/version.rb
+++ b/lib/fredric/version.rb
@@ -1,3 +1,3 @@
 module Fredric
-  VERSION = "0.0.3"
+  VERSION = "0.1.0"
 end

--- a/spec/README.md
+++ b/spec/README.md
@@ -12,12 +12,12 @@ To run a single spec file only, run something like:
 Some tests require the FRED APi Key. Make sure to set your API Key
 in the environment variable before running:
 
-    $ export FREDRIC_KEY=y0urAP1k3y
+    $ export FRED_KEY=y0urAP1k3y
     $ run spec
 
 
 Testing on CI
 --------------------------------------------------
 
-When testing on Travis or Circle, be sure to also set the FREDRIC_KEY
+When testing on Travis or Circle, be sure to also set the FRED_KEY
 environment variable.

--- a/spec/fredric/api_spec.rb
+++ b/spec/fredric/api_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 describe API do
   before :all do
-    ENV['FREDRIC_KEY'] or raise "Please set FREDRIC_KEY=y0urAP1k3y before running tests"
+    ENV['FRED_KEY'] or raise "Please set FRED_KEY=y0urAP1k3y before running tests"
   end
 
-  let(:fredric) { API.new ENV['FREDRIC_KEY'], use_cache: true }
+  let(:fredric) { API.new ENV['FRED_KEY'], use_cache: true }
 
   describe '#new' do
     it "initializes with api key" do

--- a/spec/fredric/command_line_spec.rb
+++ b/spec/fredric/command_line_spec.rb
@@ -4,12 +4,12 @@ describe CommandLine do
   let(:cli) { Fredric::CommandLine.instance }
 
   before :all do
-    ENV['FREDRIC_KEY'] or raise "Please set FREDRIC_KEY=y0urAP1k3y before running tests"
+    ENV['FRED_KEY'] or raise "Please set FRED_KEY=y0urAP1k3y before running tests"
   end
 
   before do
-    ENV['FREDRIC_CACHE_DIR'] = 'cache'
-    ENV['FREDRIC_CACHE_LIFE'] = '86400'
+    ENV['FRED_CACHE_DIR'] = 'cache'
+    ENV['FRED_CACHE_LIFE'] = '86400'
   end
 
   describe '#initialize' do
@@ -17,8 +17,8 @@ describe CommandLine do
 
     context "without environment variables" do
       before do
-        ENV['FREDRIC_CACHE_DIR'] = nil
-        ENV['FREDRIC_CACHE_LIFE'] = nil
+        ENV['FRED_CACHE_DIR'] = nil
+        ENV['FRED_CACHE_LIFE'] = nil
       end
 
       it "has cache disabled" do
@@ -28,19 +28,19 @@ describe CommandLine do
 
     context "with CACHE_DIR" do
       it "enables cache" do
-        ENV['FREDRIC_CACHE_DIR'] = 'hello'
+        ENV['FRED_CACHE_DIR'] = 'hello'
         expect(cli.fredric.cache).to be_enabled
         expect(cli.fredric.cache.dir).to eq 'hello'
-        ENV.delete 'FREDRIC_CACHE_DIR'
+        ENV.delete 'FRED_CACHE_DIR'
       end
     end
 
     context "with CACHE_LIFE" do
       it "enables cache" do
-        ENV['FREDRIC_CACHE_LIFE'] = '123'
+        ENV['FRED_CACHE_LIFE'] = '123'
         expect(cli.fredric.cache).to be_enabled
         expect(cli.fredric.cache.life).to eq 123
-        ENV.delete 'FREDRIC_CACHE_LIFE'
+        ENV.delete 'FRED_CACHE_LIFE'
       end
     end
   end
@@ -52,16 +52,16 @@ describe CommandLine do
       end
     end
 
-    context "without FREDRIC_KEY" do
+    context "without FRED_KEY" do
       let(:command) { %w[see series series_id:GNPCA] }
 
       before do
-        @auth = ENV['FREDRIC_KEY']
-        ENV.delete 'FREDRIC_KEY'
+        @auth = ENV['FRED_KEY']
+        ENV.delete 'FRED_KEY'
       end
 
       after do
-        ENV['FREDRIC_KEY'] = @auth
+        ENV['FRED_KEY'] = @auth
       end
 
       it "shows a friendly error" do


### PR DESCRIPTION
In order to be more compatible with the sister gems ([Quata][1] and [Intrinio][2]), this PR changes the environment variables for the command line from `FREDRIC_*` to `FRED_*`.

[1]: https://github.com/DannyBen/quata
[2]: https://github.com/DannyBen/intrinio