### PR TITLE
Fix failing fixture and switch to rspec_fixtures

### DIFF
--- a/fredric.gemspec
+++ b/fredric.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'runfile', '~> 0.9'
   s.add_development_dependency 'runfile-tasks', '~> 0.4'
   s.add_development_dependency 'rspec', '~> 3.5'
+  s.add_development_dependency 'rspec_fixtures', '~> 0.1'
   s.add_development_dependency 'rdoc', '~> 5.1'
   s.add_development_dependency 'byebug', '~> 9.0'
   s.add_development_dependency 'simplecov', '~> 0.14'

--- a/spec/fixtures/gnpca-meta.csv
+++ b/spec/fixtures/gnpca-meta.csv
@@ -1,2 +1,2 @@
 id,realtime_start,realtime_end,title,observation_start,observation_end,frequency,frequency_short,units,units_short,seasonal_adjustment,seasonal_adjustment_short,last_updated,popularity,notes
-GNPCA,.*,.*,Real Gross National Product,.*,Annual,A,Billions of Chained 2009 Dollars,Bil. of Chn. 2009 \$,Not Seasonally Adjusted,NSA,.*,BEA Account Code: A001RX1
+GNPCA,.*,.*,Real Gross National Product,.*,Annual,A,Billions of Chained 2009 Dollars,Bil. of Chn. 2009 \$,Not Seasonally Adjusted,NSA,.*BEA Account Code: A001RX

--- a/spec/fredric/api_spec.rb
+++ b/spec/fredric/api_spec.rb
@@ -34,14 +34,14 @@ describe API do
     context "with a response that contains at least one array" do
       it "returns a csv string" do
         result = fredric.get_csv 'category/children', category_id: 0
-        expect(result).to eq fixture('categories.csv')
+        expect(result).to match_fixture('categories.csv')
       end
     end
 
     context "with a response that does not contain any array" do
       it "returns a csv string" do
         result = fredric.get_csv 'series', series_id: 'GNPCA'
-        fixture = fixture('gnpca-meta.csv')
+        fixture = File.read 'spec/fixtures/gnpca-meta.csv'
         expect(result).to match /#{fixture}/m
       end
     end
@@ -63,7 +63,7 @@ describe API do
       fredric.save_csv filename, 'category/children', category_id: 0
       
       expect(File).to exist(filename)
-      expect(File.read filename).to eq fixture('categories.csv')
+      expect(File.read filename).to match_fixture('categories.csv')
       
       File.delete filename
     end

--- a/spec/fredric/command_line_spec.rb
+++ b/spec/fredric/command_line_spec.rb
@@ -125,7 +125,7 @@ describe CommandLine do
 
         expect {cli.execute command}.to output(expected).to_stdout
         expect(File).to exist filename
-        expect(File.read filename).to eq fixture('categories.json')
+        expect(File.read filename).to match_fixture('categories.json')
 
         File.unlink filename
       end
@@ -142,7 +142,7 @@ describe CommandLine do
 
         expect {cli.execute command}.to output(expected).to_stdout
         expect(File).to exist filename
-        expect(File.read filename).to eq fixture('categories.csv')
+        expect(File.read filename).to match_fixture('categories.csv')
 
         File.unlink filename
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,13 +14,3 @@ RSpec.configure do |config|
     APICake::Base.new.cache.flush
   end
 end
-
-
-def fixture(filename, data=nil)
-  if data
-    File.write "spec/fixtures/#{filename}", data
-    raise "Warning: Fixture data was written.\nThis is perfectly fine if it was intended,\nbut tests cannot proceed with it as a precaution."
-  else
-    File.read "spec/fixtures/#{filename}"
-  end
-end


### PR DESCRIPTION
This PR fixes the failing build.

The build failed due to a minor change in how data is returned by the API.
In addition, we now use the `rspec_fixtures` gem.